### PR TITLE
Shorten Display name in databroker addons

### DIFF
--- a/TorghastTourguide.lua
+++ b/TorghastTourguide.lua
@@ -30,7 +30,7 @@ local HotSpotState = false
 --Registers for LDB addons
 local TTGLDB = LibStub("LibDataBroker-1.1"):NewDataObject("TTGMapMini", {
 	type = "data source",
-	text = "TorghastTourguide",
+	text = "TorghastTG",
 	icon = "Interface\\Addons\\TorghastTourguide\\Icons\\icon",
 	OnClick = function(self, button, down) 
 		if (button == "RightButton") then


### PR DESCRIPTION
It's a small thing, but when you have a lot of databroker addons, the amount of display space that each uses in an addon like "Bazooka" becomes somewhat important.

All this pull request does is change what a databroker addon (e.g., "Bazooka") displays from "TorghastTourguide" to "TorghastTG". 

If you prefer, I could take the time to create an option for this (i.e., an option to set the text that is displayed in the databroker addon) ...which would be pretty quick/easy to do; but, I thought I'd propose this route first. :) 